### PR TITLE
Simplify browse for locations.

### DIFF
--- a/cleaned_data/modsbyPID/rfta:113.xml
+++ b/cleaned_data/modsbyPID/rfta:113.xml
@@ -66,7 +66,7 @@
    <subject valueURI="http://id.loc.gov/authorities/subjects/sh2009002915">
       <geographic>Dollywood (Pigeon Forge, Tenn.)</geographic>
    </subject>
-   <note displayLabel="Browse">Towns in East TN including Gatlinburg, Pigeon Forge, Sevierville and Pittman Center, TN</note>
+   <note displayLabel="Browse">Dollywood, Pigeon Forge, TN</note>
    <language>
       <languageTerm type="text" authority="iso639-2b">English</languageTerm>
    </language>

--- a/cleaned_data/modsbyPID/rfta:166.xml
+++ b/cleaned_data/modsbyPID/rfta:166.xml
@@ -124,6 +124,7 @@
          <coordinates>34.00043, -81.00009</coordinates>
       </cartographics>
    </subject>
+   <note displayLabel="Browse">Dollywood, Pigeon Forge, TN</note>
    <language>
       <languageTerm type="text" authority="iso639-2b">Spanish</languageTerm>
    </language>

--- a/cleaned_data/modsbyPID/rfta:170.xml
+++ b/cleaned_data/modsbyPID/rfta:170.xml
@@ -58,7 +58,7 @@
    <subject valueURI="http://id.loc.gov/authorities/names/n80040520">
       <geographic>Gatlinburg (Tenn.)</geographic>
    </subject>
-   <note displayLabel="Browse">Towns in East TN including Gatlinburg, Pigeon Forge, Sevierville and Pittman Center, TN</note>
+   <note displayLabel="Browse">Gatlinburg, Sevierville and Pittman Center</note>
    <language>
       <languageTerm type="text" authority="iso639-2b">English</languageTerm>
    </language>

--- a/cleaned_data/modsbyPID/rfta:21.xml
+++ b/cleaned_data/modsbyPID/rfta:21.xml
@@ -51,7 +51,7 @@ Interview with Ken Wise, 2019-10-13</title>
    <subject valueURI="http://id.loc.gov/authorities/names/n80040520">
       <geographic>Gatlinburg (Tenn.)</geographic>
    </subject>
-   <note displayLabel="Browse">Towns in East TN including Gatlinburg, Pigeon Forge, Sevierville and Pittman Center, TN</note>
+   <note displayLabel="Browse">Gatlinburg, Sevierville and Pittman Center</note>
    <subject authority="geonames" valueURI="http://sws.geonames.org/4482056">
       <geographic>Newfound Gap</geographic>
       <cartographics>

--- a/cleaned_data/modsbyPID/rfta:41.xml
+++ b/cleaned_data/modsbyPID/rfta:41.xml
@@ -53,7 +53,7 @@
    <subject valueURI="http://id.loc.gov/authorities/names/n85274941">
       <geographic>Pittman Center (Tenn.)</geographic>
    </subject>
-   <note displayLabel="Browse">Towns in East TN including Gatlinburg, Pigeon Forge, Sevierville and Pittman Center, TN</note>
+   <note displayLabel="Browse">Gatlinburg, Sevierville and Pittman Center</note>
    <subject authority="geonames" valueURI="http://sws.geonames.org/4649150">
       <geographic>Pi Beta Phi Elementary School</geographic>
       <cartographics>

--- a/cleaned_data/modsbyPID/rfta:42.xml
+++ b/cleaned_data/modsbyPID/rfta:42.xml
@@ -53,7 +53,7 @@
    <subject valueURI="http://id.loc.gov/authorities/names/n85274941">
       <geographic>Pittman Center (Tenn.)</geographic>
    </subject>
-   <note displayLabel="Browse">Towns in East TN including Gatlinburg, Pigeon Forge, Sevierville and Pittman Center, TN</note>
+   <note displayLabel="Browse">Gatlinburg, Sevierville and Pittman Center</note>
    <language>
       <languageTerm type="text" authority="iso639-2b">English</languageTerm>
    </language>

--- a/cleaned_data/modsbyPID/rfta:54.xml
+++ b/cleaned_data/modsbyPID/rfta:54.xml
@@ -58,7 +58,7 @@
    <subject valueURI="http://id.loc.gov/authorities/names/n85274941">
       <geographic>Pittman Center (Tenn.)</geographic>
    </subject>
-   <note displayLabel="Browse">Towns in East TN including Gatlinburg, Pigeon Forge, Sevierville and Pittman Center, TN</note>
+   <note displayLabel="Browse">Gatlinburg, Sevierville and Pittman Center</note>
    <subject authority="geonames" valueURI="http://sws.geonames.org/4649150">
       <geographic>Pi Beta Phi Elementary School</geographic>
       <cartographics>

--- a/cleaned_data/modsbyPID/rfta:6.xml
+++ b/cleaned_data/modsbyPID/rfta:6.xml
@@ -53,7 +53,7 @@
    <subject valueURI="http://id.loc.gov/authorities/names/n82273669">
       <geographic>Sevierville (Tenn.)</geographic>
    </subject>
-   <note displayLabel="Browse">Towns in East TN including Gatlinburg, Pigeon Forge, Sevierville and Pittman Center, TN</note>
+   <note displayLabel="Browse">Gatlinburg, Sevierville and Pittman Center</note>
    <language>
       <languageTerm type="text" authority="iso639-2b">English</languageTerm>
    </language>


### PR DESCRIPTION
## What Does This Do

Simplifies the location browse concepts for RFTA.

## Why are we doing this

We're having some trouble with location browse.  To simplify this for go live, we're splitting this into two concepts.

## Why are you opening a p.r.

To unblock Notch 8, I need to push this temporarily to Fedora.  If it needs to change, we can do after go live.